### PR TITLE
add option to hide country flag on header

### DIFF
--- a/header.php
+++ b/header.php
@@ -56,7 +56,9 @@
                                 </a>
                                 <span class="country_id">
                                     <?php
-                                    if ( get_option( 'country_code' ) ) {
+                                    global $_set;
+                                    $settings = $_set->settings;
+                                    if ( get_option( 'country_code' ) && (!$settings['hide_flag']) ) {
                                         print do_shortcode( '<span class="flag c_' . strtolower( get_option( 'country_code' ) ) . '"></span>' ); }
                                     ?>
                                   <span class="name"><?php print get_bloginfo( 'name' ); ?></span>

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1,5 +1,3 @@
-
-
 <?php 
 use Queulat\Forms\Element\Div;
 use Queulat\Forms\Element\Form;
@@ -10,6 +8,7 @@ use Queulat\Forms\Element\Input_Url;
 use Queulat\Forms\Element\WP_Editor;
 use Queulat\Forms\Element\Input_Text;
 use Queulat\Forms\Element\Input;
+use Queulat\Forms\Element\Input_Checkbox;
 use Queulat\Forms\Element\Select;
 
 class ThemeSettings
@@ -155,6 +154,20 @@ class ThemeSettings
                             ]
                         ),
                         Node_Factory::make(
+                            Input_Checkbox::class,
+                            [
+                                'name' => 'hide_flag',
+                                'label' => 'Hide country flag?',
+                                'value' => (!empty($data['hide_flag'])) ? $data['hide_flag'] : '',
+                                'attributes' => [
+                                    'class' => 'widefat'
+                                ],
+                                'options' => array(
+                                    '1'          => 'yes'
+                                )
+                            ]
+                        ),
+                        Node_Factory::make(
                             WP_Nonce::class,
                             [
                                 'properties' => [
@@ -190,8 +203,6 @@ class ThemeSettings
     }
     public function saveSettings()
     {
-        // echo '<pre>'; print_r($_POST); echo '</pre>';
-        // die();
         if (empty($_POST['action'])) return;
         if ($_POST['action'] !== 'update_site_settings') return;
         if (!wp_verify_nonce($_POST['_site_settings_nonce'], 'update_site_settings')) wp_die(_x("You are not supposed to do that", 'site settings error', 'cc-chapters'));
@@ -203,6 +214,7 @@ class ThemeSettings
             'sidebar-3-background',
             'sidebar-4-background',
             'sidebar-5-background',
+            'hide_flag'
         );
         $raw_post = stripslashes_deep($_POST);
         $data = array_intersect_key($raw_post, array_combine($fields, $fields));


### PR DESCRIPTION
Fixes #24 

**Description**
Option added to the Dashboard > custom settings screen to hide the country flag in header

![Screen Shot 2019-10-07 at 1 07 44 PM](https://user-images.githubusercontent.com/894708/66328984-097f7600-e904-11e9-8d8e-53853280fdda.png)

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
