### PR TITLE
fix menu style on phone screen

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -8969,7 +8969,7 @@ button.donate.arrow:hover::after,
 
 .toggled-on .mobile-navigation {
   display: none;
-  height: 285px;
+  height: 100%;
   box-shadow: 0 0 15px 0px rgba(0, 0, 0, 0.8); }
 
 .mobile-navigation ul {

--- a/scss/components/_temp.scss
+++ b/scss/components/_temp.scss
@@ -1802,7 +1802,7 @@ video.wp-video-shortcode {
 }
 .toggled-on .mobile-navigation {
     display: none;
-    height: 285px;
+    height: 100%;
     box-shadow: 0 0 15px 0px rgba(0,0,0,.8);
 }
 .mobile-navigation ul {


### PR DESCRIPTION
## Fixes
Fixes creativecommons/tech-support#420

## Description
This style fix replaces the fixed height on the menu container element to avoid the reported error in creativecommons/tech-support#420
I'll draft a new release

## Checklist 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
