### PR TITLE
fix wrapper issue on chrome

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2750,7 +2750,8 @@ body.admin-bar .site-header.sticky {
   .wrapper-main {
     -webkit-flex: 1 0 70%;
         -ms-flex: 1 0 70%;
-            flex: 1 0 70%; } }
+            flex: 1 0 70%;
+    width: 70%; } }
 
 @media (min-width: 56.875em) {
   .wrapper-sidebar {

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * Release serial number - Used to bust the cache. Please update
  *                         any time you change CSS or JS.
  */
-define( 'CC_CSS_RELEASE_SERIAL_NUMBER', '2020.04.1' );
+define( 'CC_CSS_RELEASE_SERIAL_NUMBER', '2020.05.1' );
 /**
  * Include telated files
 */
@@ -71,7 +71,7 @@ class site
 	protected $settings;
 
 	const id = __CLASS__;
-	const theme_ver = '2020.04.1';
+	const theme_ver = '2020.05.1';
 	const theme_settings_permissions = 'edit_theme_options';
 	private function __construct()
 	{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-chapters-theme",
-  "version": "2020.04.1",
+  "version": "2020.05.1",
   "description": "Creative Commons Chapter websites WordPress theme",
   "directories": {},
   "author": "Creative Commons",

--- a/scss/base/_layout.scss
+++ b/scss/base/_layout.scss
@@ -347,6 +347,7 @@ body.admin-bar .site-header.sticky {
     
     @include breakpoint (desktop-sm-layout) {
         flex: 1 0 70%;
+        width: 70%;
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Author: Creative Commons
 Author URI: https://creativecommons.org/
 Description: The Creative Commons Chapter theme
 Template: twentysixteen
-Version: 2020.04.1
+Version: 2020.05.1
 License: GPL2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Fixes
Fixes #36

## Description
This PR fixes the width of the main wrapper (with the same percentage of the flex column) to avoid an issue on chrome with certain pages.
Also updates the theme version

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
